### PR TITLE
update link

### DIFF
--- a/bridgedb/distributors/https/templates/base.html
+++ b/bridgedb/distributors/https/templates/base.html
@@ -52,7 +52,7 @@ ${next.body(strings, rtl=rtl, lang=lang, **kwargs)}
             <h4>${_(strings.FAQ[0])}</h4>
             <p>
               ${_(strings.FAQ[1]) % \
-                 ("""<a href="https://www.torproject.org/docs/bridges">""", "</a>")}
+                 ("""<a href="https://tb-manual.torproject.org/bridges/">""", "</a>")}
             </p>
 
             <h4>${_(strings.OTHER_DISTRIBUTORS[0])}</h4>


### PR DESCRIPTION
just a little patch to move to new documentation.
the old link was pointing to the old docs, that are not maintained anymore.